### PR TITLE
Numerous single-character bug-fixes

### DIFF
--- a/src/makefile.ts
+++ b/src/makefile.ts
@@ -34,7 +34,7 @@ export default async function findMakefile(path?: string): Promise<Makefile> {
         return loadMakefile(process.stdin);
     } else if (path) {
         const location = await fs.realpath((path.startsWith('/') ? path :
-            path.startsWith('~/') ? os.homedir() + path.slice(1) :
+            path.startsWith('~/') ? os.homedir() + path.slice(2) :
                 path.startsWith('./') ? process.cwd() + path.slice(2) :
                     path)
             .replaceAll('/./', '/')

--- a/src/run.ts
+++ b/src/run.ts
@@ -33,9 +33,9 @@ export function matches(target: string, request: string): boolean {
 }
 
 export default async function buildArtifacts(artifacts: string[]): Promise<void> {
-    const { makefile, makefilePath: origin, force } = config.get()
+    const { makefile, makefilePath: origin, force } = config.get();
 
-    for (const i of artifacts.length > 1 ? artifacts : [Object.keys(config.get().makefile.targets)[0]]) {
+    for (const i of artifacts.length >= 1 ? artifacts : [Object.keys(config.get().makefile.targets)[0]]) {
         log.verbose(`Resolving artifact: ${i}`);
 
         const absTarget = toAbs(i, origin);

--- a/test/makefile.json
+++ b/test/makefile.json
@@ -1,0 +1,16 @@
+{
+    "targets": {
+        "target1": {
+            "dependencies": ["target2"],
+            "run": "touch target1"
+        },
+        "target2": {
+            "dependencies": ["target3"],
+            "run": "touch target2"
+        },
+        "target3": {
+            "dependencies": ["match.js"],
+            "run": "touch match.js"
+        }
+    }
+}


### PR DESCRIPTION
* The path resolution strategy was replacing `~/` incorrectly.
* Using the first specified target name if no targets were provided was done if the list was at least two long, when it should have been 1. 