### PR TITLE
Globbing issues

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,8 +37,6 @@ export default async function main(argv: string[], pkg: typeof import('../packag
             mkjson.config.setState({logLevel: logLevel(next())});
         else if (i == '--force' || i == '-B' || i == '-f')
             mkjson.config.setState({force: true});
-        else if (i == '--all')
-            mkjson.config.setState({all: true});
         else if (i == '--synchronous' || i == '-S')
             mkjson.config.setState({synchronous: true});
         else if (i == '--no-scripts')

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,6 @@ import StateManager from "@j-cake/jcake-utils/state";
 export interface Args {
     artifacts: string[],
     force: boolean,
-    all: boolean,
     synchronous: boolean,
     logLevel: 'err' | 'info' | 'verbose' | 'debug',
     makefilePath: string[],
@@ -13,7 +12,6 @@ export interface Args {
 
 export const config = new StateManager<Args>({
     force: false,
-    all: false,
     logLevel: 'info',
     synchronous: false,
     artifacts: [],

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -56,6 +56,5 @@ export const insertWildcards = function (dep: string, wildcards: string[]): stri
     for (const [a, i] of iter.collect([dep, ...wildcards].entries()).reverse())
         result = result.replaceAll(`\\${a}`, i);
 
-    console.log("wildcards: insertWildcards", wildcards);
     return decodeURIComponent(result);
 }

--- a/src/core/targetList.ts
+++ b/src/core/targetList.ts
@@ -1,9 +1,11 @@
+import chalk from "chalk";
 import StateManager from "@j-cake/jcake-utils/state";
 import {Iter} from '@j-cake/jcake-utils/iter';
 
 import {config} from "./config.js";
 import lsGlob, {toAbs} from "./path.js"
 import * as plugins from "./plugin.js";
+import log from "./log.js";
 
 export const targets: StateManager<TargetList> = new StateManager({});
 
@@ -38,6 +40,8 @@ export async function getRule(artifactHint: string): Promise<MatchResult[]> {
             .map(i => i.exec(artifact))
             .filter(i => i.file.length > 0);
 
+        log.debug(`Fetching rules for ${chalk.yellow(artifact)}`);
+
         const matchesArtifact = await Iter(lsGlob(artifact))
             .map(artifact => matchers
                 .map(i => i.exec(artifact.file))
@@ -45,19 +49,12 @@ export async function getRule(artifactHint: string): Promise<MatchResult[]> {
             .flat()
             .collect();
 
+        log.debug(`Matched values`, matchesArtifact);
+
         const allTargets = [...matchesTarget, ...matchesArtifact];
 
         if (allTargets.length > 0)
-            if (config.get().all)
-                return allTargets.map(i => ({
-                    ...i,
-                    rule
-                }));
-            else
-                return [{
-                    ...allTargets[0],
-                    rule,
-                }]
+            return allTargets.map(i => ({ ...i, rule }));
     }
 
     return [];

--- a/src/plugins/glob.ts
+++ b/src/plugins/glob.ts
@@ -8,16 +8,9 @@ export function createGlob(glob: string): Plugin.Glob {
         .replaceAll('*', '(.*)')
         .replaceAll('+', '([^\/]*)')) + '$', 'g');
 
-    const exe = str => _.chain((regExp.lastIndex = -1, regExp.exec(str) ?? []))
-        .reduce((a, i, b) => b == 0 ? [i, a[1], str] as typeof a : [a[0], [...a[1], i], str] as typeof a, ['', [], ''] as [string, string[], string])
-        .zip(['file', 'wildcards', 'raw'])
-        .map(i => [i[1], i[0]])
-        .fromPairs()
-        .value() as { file: string, wildcards: string[], raw: string };
-
     return {
         exec: str => _.chain((regExp.lastIndex = -1, regExp.exec(str) ?? []))
-            .reduce((a, i, b) => b == 0 ? [i ?? '', a[1], str] as typeof a : [a[0] ?? '', [...a[1], i], str] as typeof a, ['', [], ''] as [string, string[], string])
+            .reduce((a, i, b) => b == 0 ? [i ?? '', a[1], glob] as typeof a : [a[0] ?? '', [...a[1], i], glob] as typeof a, ['', [], ''] as [string, string[], string])
             .zip(['file', 'wildcards', 'raw'])
             .map(i => [i[1], i[0]])
             .fromPairs()


### PR DESCRIPTION
General improvements in working with multiple matches for globbing patterns.

I'd noticed that you could have a rule like `/*.js` and when you'd do ```mkjson *.js``` in a directory containing multiple `.js` files, you'd only get the first match. Assuming this issue was related to how globbing patterns are handled, revealed that I'd previously already dealt with the issue and simply added an option to avoid it. Making it on by default means the program makes more sense to use. 