### PR TITLE
Wildcards in artifacts referencing targets

### DIFF
--- a/.idea/runConfigurations/Run.xml
+++ b/.idea/runConfigurations/Run.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run" type="NodeJSConfigurationType" application-parameters="--log-level debug -m makefile.json5 build/index.js" node-parameters="--enable-source-maps=true" path-to-js-file="../build/run.js" working-dir="$PROJECT_DIR$/example">
+    <EXTENSION ID="com.jetbrains.nodejs.run.NodeStartBrowserRunConfigurationExtension">
+      <browser with-js-debugger="true" />
+    </EXTENSION>
     <method v="2">
       <option name="TypeScript.Before.Run" enabled="true" FAIL_ON_ERROR="true" CONFIG_PATH="$PROJECT_DIR$/tsconfig.json" />
       <option name="NpmBeforeRunTask" enabled="true">

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -10,11 +10,13 @@ import * as plugin from './plugin.js';
  * @param path {string} The path to convert to absolute
  * @param cwd {string} The directory from which relative paths are resolved
  */
-export const toAbs = (path: string, cwd: string = process.cwd()): string => (path.startsWith('/') ? path : (`./${path}`
-    .replace(/^\.\.\//g, cwd + '/../')
-    .replace(/^\.\//g, cwd + '/')
-    .replace(/^~\//g, os.homedir() + '/'))
-    .replace(/^#\//g, config.get().makefilePath[0] + '/'))
+export const toAbs = (path: string, cwd: string = process.cwd() + '/'): string => (path.startsWith('/') ? path : (`./${path}`
+    .replace(/^\.\/~\//g, os.homedir() + '/'))
+    .replace(/^\.\/#\//g, config.get().makefilePath[0]?.match(/^(.*\/)[^\/]*/)?.[1] ?? cwd)
+
+    .replace(/^\.\/\.\.\//g, cwd + '../')
+    .replace(/^\.\//g, cwd))
+
     .replaceAll(/[^\/]*\/\.\./g, '')
     .replaceAll('./', '')
     .replaceAll(/\/+/g, '/');

--- a/src/core/plugin-api.ts
+++ b/src/core/plugin-api.ts
@@ -20,14 +20,14 @@ export async function loadMakefile(hint: string): Promise<void> {
 
         log.debug(`Attempting loader: ${chalk.yellow(a)}`);
         const makefile = await i.loadMakefile(hint)
-            .catch(err => (log.debug(err), null));
+            .catch(err => void log.debug(err));
 
-        if (makefile) {
-            config.setState(prev => ({makefilePath: [...prev.makefilePath, hint]}));
+        if (makefile?.targets) {
+            config.setState(prev => ({makefilePath: [...prev.makefilePath, makefile.path]}));
 
             return void targets.setState(prev => ({
                 ...prev,
-                ...makefile
+                ...makefile.targets
             }));
         } else
             log.debug(`Loader returned nothing`);

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -14,7 +14,7 @@ export type Plugin = Partial<{
      * Finds and loads a makefile from a (usually provided by CLI) hint used to locate it.
      * @param hint Where the makefile is to be loaded from
      */
-    loadMakefile(hint: string): Promise<Nullable<TargetList>>,
+    loadMakefile(hint: string): Promise<Nullable<{ targets: TargetList, path: string, hint: string }>>,
     /**
      * Creates a function which returns whether a string matches a globbing pattern
      * @param glob The glob string understood by the returned function
@@ -31,7 +31,7 @@ export let glob: Plugin['createGlob'];
  * @param source
  */
 export async function loadPlugin(source: string): Promise<Plugin> {
-    const fileDir = Path.toAbs(source, import.meta.url.match(/^file:\/\/(\/.*)\/[^\/]*$/)?.[1]);
+    const fileDir = Path.toAbs(source, import.meta.url.match(/^file:\/\/(\/.*\/)[^\/]*$/)?.[1]);
 
     if (!await fs.stat(fileDir).then(res => res.isFile() || res.isSymbolicLink()).catch(() => false))
         throw log.err(`Invalid plugin format: Plugins must be real files`);
@@ -51,7 +51,7 @@ export async function loadPlugin(source: string): Promise<Plugin> {
 
 export interface Glob {
     matches(str: string): boolean,
-    exec(str: string): { file: string, wildcards: string[], raw: string }
+    exec(str: string): { file: string, wildcards: string[], raw: string, glob: string }
 }
 
 export interface SchemeHandler {

--- a/src/core/targetList.ts
+++ b/src/core/targetList.ts
@@ -1,10 +1,12 @@
 import chalk from "chalk";
+import _ from 'lodash';
 import StateManager from "@j-cake/jcake-utils/state";
 import {Iter} from '@j-cake/jcake-utils/iter';
 
 import lsGlob, {toAbs} from "./path.js"
 import * as plugins from "./plugin.js";
 import log from "./log.js";
+import {config} from "./config.js";
 
 export const targets: StateManager<TargetList> = new StateManager({});
 
@@ -24,7 +26,7 @@ export declare type Rule = Partial<{
 /**
  * The list of rules which a glob string matches
  */
-export type MatchResult = { rule: Rule, file: string, wildcards: string[] };
+export type MatchResult = { rule: Rule, file: string, wildcards: string[], raw: string, glob: string };
 
 /**
  * Search for a rule matching a target in the received list of rules
@@ -32,8 +34,24 @@ export type MatchResult = { rule: Rule, file: string, wildcards: string[] };
  */
 export async function getRule(artifactHint: string): Promise<MatchResult[]> {
     const artifact = toAbs(artifactHint);
+    const artifactGlob = plugins.API.createGlob(artifact);
+    const out: MatchResult[] = Object.entries(targets.get())
+        .map(([a, i]) => [i.phony ? a : toAbs(a), i] as [string, Rule])
+        .map(([a, i]) => ({
+            ...artifactGlob.exec(a),
+            rule: i
+        }))
+        .filter(i => i.file.length > 0);
+
+    // TODO: Handle artifact containing wildcards
+
+    // if (out.length > 0 && !config.get().force)
+    //     return out;
+
     for (const [target, rule] of Object.entries(targets.get())) {
-        const matchers = target.split(';').map(target => plugins.API.createGlob(toAbs(target)));
+        const matchers = target.split(';')
+            .map(i => toAbs(i))
+            .map(target => plugins.API.createGlob(target));
 
         const matchesTarget = matchers
             .map(i => i.exec(artifact))
@@ -48,13 +66,18 @@ export async function getRule(artifactHint: string): Promise<MatchResult[]> {
             .flat()
             .collect();
 
-        log.debug(`Matched values`, matchesArtifact);
+        log.debug(`Matched values`, matchesTarget, matchesArtifact);
 
-        const allTargets = [...matchesTarget, ...matchesArtifact];
-
-        if (allTargets.length > 0)
-            return allTargets.map(i => ({...i, rule}));
+        out.push(...[...matchesTarget, ...matchesArtifact].map(i => ({...i, rule})));
     }
 
-    return [];
+    return _.uniqWith(out, (i, j) => _.isEqual({
+        file: i.file,
+        wildcards: i.wildcards,
+        rule: i.rule
+    }, {
+        file: j.file,
+        wildcards: j.wildcards,
+        rule: j.rule
+    }));
 }

--- a/src/plugins/glob.ts
+++ b/src/plugins/glob.ts
@@ -9,12 +9,17 @@ export function createGlob(glob: string): Plugin.Glob {
         .replaceAll('+', '([^\/]*)')) + '$', 'g');
 
     return {
-        exec: str => _.chain((regExp.lastIndex = -1, regExp.exec(str) ?? []))
-            .reduce((a, i, b) => b == 0 ? [i ?? '', a[1], glob] as typeof a : [a[0] ?? '', [...a[1], i], glob] as typeof a, ['', [], ''] as [string, string[], string])
-            .zip(['file', 'wildcards', 'raw'])
-            .map(i => [i[1], i[0]])
-            .fromPairs()
-            .value() as { file: string, wildcards: string[], raw: string },
+        exec(raw: string) {
+            const [file, ...wildcards] = regExp.exec(raw) ?? ['', ''];
+            return {file, wildcards, raw, glob};
+        },
+        // my adventures in one-liners was short-lived 🙁
+        // exec: str => _.chain((regExp.lastIndex = -1, regExp.exec(str) ?? []))
+        //     .reduce((a, i, b) => b == 0 ? [i ?? '', a[1], glob] as typeof a : [a[0] ?? '', [...a[1], i], glob] as typeof a, ['', [], ''] as [string, string[], string])
+        //     .zip(['file', 'wildcards', 'raw'])
+        //     .map(i => [i[1], i[0]])
+        //     .fromPairs()
+        //     .value() as { file: string, wildcards: string[], raw: string },
         matches: regExp.test
     };
 }

--- a/src/plugins/js.ts
+++ b/src/plugins/js.ts
@@ -1,14 +1,18 @@
 import chalk from 'chalk';
 import * as core from '#core';
 
-export async function loadMakefile(hint: string): Promise<core.TargetList> {
+export async function loadMakefile(hint: string): Promise<Nullable<{ path: string, hint: string, targets: core.TargetList }>> {
     const path = core.Path.toAbs(hint);
 
     const makefile = await import(path)
         .catch(err => (['debug'].includes(core.config.get().logLevel) && core.log.err(err), null)); // the rest is handled by ../lib.ts
 
     if (makefile)
-        return core.Makefile.targets.get();
+        return {
+            path,
+            hint,
+            targets: core.Makefile.targets.get()
+        };
 
     else throw `Invalid makefile: ${chalk.blue(path)}`;
 }

--- a/src/plugins/json.ts
+++ b/src/plugins/json.ts
@@ -1,7 +1,7 @@
 import {promises as fs} from 'node:fs';
 import chalk from "chalk";
 
-import {log, Plugin, TargetList} from "#core";
+import {log, Plugin, TargetList, Path} from "#core";
 import * as shell from '../shell.js';
 
 export type JSONRule = Partial<{
@@ -165,20 +165,25 @@ export async function buildMakefile(makefile: JSONMakefile): Promise<TargetList>
  * Load a JSON makefile
  * @param hint Can be any file ending in `.json` or `.json5`
  */
-export async function loadMakefile(hint: string): Promise<TargetList> {
-    if (!['json', 'json5'].some(i => hint.toLowerCase().endsWith(i)))
+export async function loadMakefile(hint: string): Promise<{ targets: TargetList, path: string, hint: string }> {
+    const abs = Path.toAbs(hint);
+    if (!['json', 'json5'].some(i => abs.toLowerCase().endsWith(i)))
         throw `${chalk.blue('.json')} or similar extensions are required`;
 
-    if (!await fs.stat(hint).then(stat => stat.isFile() || stat.isSymbolicLink()).catch(() => false))
+    if (!await fs.stat(abs).then(stat => stat.isFile() || stat.isSymbolicLink()).catch(() => false))
         throw `Expected real file`;
 
     const {default: json} = await import('json5').catch(err => ({default: JSON}));
 
-    const buffer = await Plugin.API.fetch(hint, 'utf8');
+    const buffer = await Plugin.API.fetch(abs, 'utf8');
     const makefile = json.parse(buffer);
 
     if (isMakefile(makefile))
-        return await buildMakefile(makefile);
+        return {
+            path: abs,
+            targets: await buildMakefile(makefile),
+            hint
+        };
 
     else throw `Unexpected makefile schema`;
 }

--- a/test/glob.js
+++ b/test/glob.js
@@ -5,6 +5,10 @@ import {core} from 'mkjson';
 await core.loadPlugin('../build/fs.js');
 await core.loadPlugin('../build/glob.js');
 
+const state = core.config.setState(prev => ({
+    makefilePath: [...prev.makefilePath, process.cwd() + '/bin/makefile.json5']
+}));
+
 const glob = core.lsGlob;
 const wildcards = core.Path.insertWildcards;
 const lines = rl.createInterface(process.stdin, process.stdout)

--- a/test/path.js
+++ b/test/path.js
@@ -3,6 +3,10 @@ import {promises as rl} from "node:readline";
 // import glob, * as path from '../build/ts/src/core/path.js';
 import target, {core} from 'mkjson';
 
+const state = core.config.setState(prev => ({
+    makefilePath: [...prev.makefilePath, process.cwd() + '/bin/makefile.json5']
+}));
+
 const q = rl.createInterface(process.stdin, process.stdout);
 while (true)
     console.log(await q.question('$ ').then(path => core.Path.toAbs(path)));

--- a/test/regexp.js
+++ b/test/regexp.js
@@ -1,0 +1,19 @@
+import {promises as rl} from 'node:readline';
+
+import * as mkjson from 'mkjson';
+
+const toAbs = mkjson.core.Path.toAbs;
+
+const regExp = new RegExp('^' + decodeURIComponent(process.argv[2]
+    .replaceAll(/([.\-\/^$?\[\]{}])/g, '\\$1')
+    .replaceAll('*', '(.*)')
+    .replaceAll('+', '([^\/]*)')) + '$', 'g');
+
+const q = rl.createInterface(process.stdin, process.stdout);
+
+while (true) {
+    const raw = await q.question('$ ');
+    const [file, ...wildcards] = regExp.exec(toAbs(raw)) ?? ['', ''];
+
+    console.log({file, wildcards, raw});
+}


### PR DESCRIPTION
Wildcards can find any file, or any target, but not multiple targets at once from a single artifact specifier. Now they can.